### PR TITLE
Make only assertion methods (`assert(_*)`) published

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ branches:
   only:
     - master
 before_install:
-  - gem update --system --no-doc
   - gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true
   - gem install bundler -v '~> 1.0'
 before_script:

--- a/README.md
+++ b/README.md
@@ -44,8 +44,9 @@ MyMath.abs('42')
 #   <String>.
 ```
 
-Note that `Assert` provides the same methods defined in `Test::Unit::Assertions` of `test-unit` gem
-except they throw not `Test::Unit::AssertionFailedError` but `AssertionError` when an assertion fails.
+Note that `Assert` provides the same `assert(_*)` methods defined in `Test::Unit::Assertions`
+of `test-unit` gem except they throw not `Test::Unit::AssertionFailedError` but `AssertionError`
+when an assertion fails.
 
 See also: https://test-unit.github.io/test-unit/en/Test/Unit/Assertions.html
 

--- a/test/assert_test.rb
+++ b/test/assert_test.rb
@@ -13,6 +13,13 @@ class AssertTest < Test::Unit::TestCase
     end
   end
 
+  test "should provide only `assert(_*)` methods" do
+    assertion_method_pattern = /\Aassert(_.+)?\z/
+
+    assert_empty(Assert.instance_methods)
+    assert(Assert.private_instance_methods.all?(&assertion_method_pattern.method(:match?)))
+  end
+
   test "should raise `AssertionError` when the preconditions aren't satisfied" do
     assert_raise(AssertionError) { MyMath.abs("42") }
   end


### PR DESCRIPTION
This PR makes only assertion methods (`assert(_*)`) published.