### PR TITLE
Migrate the assertion methods' backend to `minitest`

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ class Stack
   end
 
   def pop
-    assert_not_empty(@store)
+    assert(!@store.empty?)
     @store.pop
   end
 
@@ -48,7 +48,7 @@ class Stack
   end
 end
 
-Stack.new.pop #=> <[]> was expected to not be empty.>
+Stack.new.pop #=> AssertionError (Expected false to be truthy.)
 ```
 
 Or just call them with the module as a receiver:
@@ -56,19 +56,18 @@ Or just call them with the module as a receiver:
 ```ruby
 class Stack
   def peek
-    ::Assert.assert_not_empty(@store)
+    ::Assert.assert(!@store.empty?)
     @store.last
   end
 end
 
-Stack.new.peek #=> <[]> was expected to not be empty.>
+Stack.new.peek #=> AssertionError (Expected false to be truthy.)
 ```
 
-Note that `Assert` provides the same `assert(_*)` methods defined in `Test::Unit::Assertions`
-of `test-unit` gem except they throw not `Test::Unit::AssertionFailedError` but `AssertionError`
-when an assertion fails.
+Note that `Assert` provides `aseert` and `assert_*` methods same as in `Minitest::Assertions`
+except they throw not `Minitest::Assertion` but `AssertionError` when an assertion fails.
 
-See also: https://test-unit.github.io/test-unit/en/Test/Unit/Assertions.html
+See also: http://docs.seattlerb.org/minitest/Minitest/Assertions.html
 
 ## Contributing
 

--- a/lib/standard_assert.rb
+++ b/lib/standard_assert.rb
@@ -1,48 +1,22 @@
 # frozen_string_literal: true
 
-require "test/unit/assertions"
-require_relative "standard_assert/assertion_error"
+require_relative "standard_assert/assertions"
 require_relative "standard_assert/version"
 
 module StandardAssert
-  using(::Module.new do
-    assertions = ::Object.new.extend(::Test::Unit::Assertions.dup.tap do |mod|
-      mod.module_exec do
-        const_set :AssertionFailedError, ::AssertionError
-      end
-    end)
+  assertion_method_pattern = /\Aassert(?:_\w+)?\z/
 
-    refine ::StandardAssert do
-      define_method(:assertions) { assertions }
-    end
-
-    # NOTE: It isn't working to call `define_singleton_method` in `refine ::StandardAssert` block
-    refine ::StandardAssert.singleton_class do
-      define_method(:assertions) { assertions }
-    end
-  end)
-
-  ASSERTION_METHOD_PATTERN = /\Aassert(_.+)?\z/.freeze
-  private_constant :ASSERTION_METHOD_PATTERN
-
-  class << self
-    def to_s
-      "Assert"
-    end
-
-    alias inspect to_s
-    alias name to_s
-  end
-
-  ::Test::Unit::Assertions.public_instance_methods
-                          .select(&ASSERTION_METHOD_PATTERN.method(:match?))
-                          .each do |name|
+  ::StandardAssert::Assertions.instance
+                              .public_methods
+                              .select(&assertion_method_pattern.method(:match?))
+                              .each do |name|
     class_eval <<~CODE, __FILE__, __LINE__ + 1
       module_function def #{name}(*args, &block)
-        assertions.public_send(:#{name}, *args, &block)
+        ::StandardAssert::Assertions.instance.public_send(:#{name}, *args, &block)
       end
     CODE
   end
 end
 
-Assert = StandardAssert
+# HACK: Call `dup` to make `inspect`, `name`, `to_s` and so on return `"Assert"`
+Assert = StandardAssert.dup

--- a/lib/standard_assert/assertion_error.rb
+++ b/lib/standard_assert/assertion_error.rb
@@ -1,34 +1,8 @@
 # frozen_string_literal: true
 
-require "forwardable"
-require "test/unit/assertion-failed-error"
-
 module StandardAssert
-  class AssertionError < ::StandardError
-    extend ::Forwardable
-
-    OriginalError = ::Test::Unit::AssertionFailedError
-    private_constant :OriginalError
-
-    def_delegators(
-      :@original_error,
-      *(OriginalError.instance_methods - superclass.instance_methods)
-    )
-
-    class << self
-      def to_s
-        "AssertionError"
-      end
-
-      alias inspect to_s
-      alias name to_s
-    end
-
-    def initialize(message = nil, options = nil)
-      @original_error = OriginalError.new(message, options)
-      super(@original_error.message)
-    end
-  end
+  class AssertionError < ::StandardError; end
 end
 
-AssertionError = StandardAssert::AssertionError
+# HACK: Call `dup` to make `inspect`, `name`, `to_s` and so on return `"AssertionError"`
+AssertionError = StandardAssert::AssertionError.dup

--- a/lib/standard_assert/assertions.rb
+++ b/lib/standard_assert/assertions.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "minitest"
+require "singleton"
+require_relative "assertion_error"
+
+module StandardAssert
+  class Assertions # :nodoc:
+    include ::Minitest::Assertions
+    include ::Singleton
+
+    def initialize
+      @assertions = 0
+    end
+
+    # Override
+    def assert(test, msg = nil)
+      super
+    rescue ::Minitest::Assertion => e
+      raise ::AssertionError, e.message
+    end
+
+    protected # rubocop:disable Style/AccessModifierDeclarations
+
+    attr_reader :assertions
+
+    # NOTE: `Minitest::Assertions` expects to be able to increment an instance accessor named
+    # `assertions`, but we don't need the accessor because it's used for reporting test results.
+    # So define a writer that does nothing and always returns the same value.
+    def assertions=(_val)
+      @assertions
+    end
+  end
+end

--- a/standard_assert.gemspec
+++ b/standard_assert.gemspec
@@ -28,5 +28,4 @@ but also production.}
   spec.add_development_dependency "rubocop"
   spec.add_development_dependency "simplecov"
   spec.add_dependency "minitest", ">= 5.0"
-  spec.add_dependency "test-unit", ">= 3.0"
 end

--- a/standard_assert.gemspec
+++ b/standard_assert.gemspec
@@ -27,5 +27,6 @@ but also production.}
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "rubocop"
   spec.add_development_dependency "simplecov"
+  spec.add_dependency "minitest", ">= 5.0"
   spec.add_dependency "test-unit", ">= 3.0"
 end

--- a/test/assert_test.rb
+++ b/test/assert_test.rb
@@ -13,7 +13,7 @@ class AssertTest < Test::Unit::TestCase
     end
 
     def pop
-      assert_not_empty(@store)
+      assert(!@store.empty?)
       @store.pop
     end
 
@@ -26,7 +26,7 @@ class AssertTest < Test::Unit::TestCase
   ## Example2
   class Stack
     def peek
-      ::Assert.assert_not_empty(@store)
+      ::Assert.assert(!@store.empty?)
       @store.last
     end
   end
@@ -36,7 +36,7 @@ class AssertTest < Test::Unit::TestCase
   end
 
   test "should provide only `assert(_*)` methods" do
-    assertion_method_pattern = /\Aassert(_.+)?\z/
+    assertion_method_pattern = /\Aassert(?:_\w+)?\z/
 
     assert_empty(::Assert.instance_methods)
     assert(::Assert.private_instance_methods.all?(&assertion_method_pattern.method(:match?)))

--- a/test/assert_test.rb
+++ b/test/assert_test.rb
@@ -2,65 +2,65 @@
 
 require "test_helper"
 
-class AssertTest < Test::Unit::TestCase
-  # NOTE: same as one in README
-  ## Example1
-  class Stack
-    include ::Assert
+# NOTE: same as one in README
+## Example1
+class Stack
+  include ::Assert
 
-    def initialize
-      @store = []
-    end
-
-    def pop
-      assert(!@store.empty?)
-      @store.pop
-    end
-
-    def push(element)
-      @store.push(element)
-      self
-    end
+  def initialize
+    @store = []
   end
 
-  ## Example2
-  class Stack
-    def peek
-      ::Assert.assert(!@store.empty?)
-      @store.last
-    end
+  def pop
+    assert(!@store.empty?)
+    @store.pop
   end
 
-  def setup
+  def push(element)
+    @store.push(element)
+    self
+  end
+end
+
+## Example2
+class Stack
+  def peek
+    ::Assert.assert(!@store.empty?)
+    @store.last
+  end
+end
+
+describe Assert do
+  before do
     @stack = Stack.new
   end
 
-  test "should provide only `assert(_*)` methods" do
+  it "should provide only `assert` and `assert_*` methods" do
     assertion_method_pattern = /\Aassert(?:_\w+)?\z/
 
     assert_empty(::Assert.instance_methods)
     assert(::Assert.private_instance_methods.all?(&assertion_method_pattern.method(:match?)))
   end
 
-  sub_test_case("when using the assert methods in a class that mixin the module") do
-    test "should raise `AssertionError` when the preconditions aren't satisfied" do
-      assert_raise(::AssertionError) { @stack.pop }
+  describe "when using the assert methods in a class that mixin the module" do
+    it "should raise `AssertionError` when the preconditions aren't satisfied" do
+      assert_raises(::AssertionError) { @stack.pop }
     end
 
-    test "should not raise any errors when the preconditions are satisfied" do
-      @stack.push(42)
-      assert_nothing_raised { @stack.pop }
+    it "should not raise any errors when the preconditions are satisfied" do
+      @stack.push(value = 42)
+      assert_equal value, @stack.pop
     end
   end
 
-  sub_test_case("when calling the assert methods with the module as a receiver") do
-    test "should raise `AssertionError` when the preconditions aren't satisfied" do
-      assert_raise(::AssertionError) { @stack.peek }
+  describe "when calling the assert methods with the module as a receiver" do
+    it "should raise `AssertionError` when the preconditions aren't satisfied" do
+      assert_raises(::AssertionError) { @stack.peek }
     end
 
-    test "should not raise any errors when the preconditions are satisfied" do
-      @stack.push(42)
-      assert_nothing_raised { @stack.peek }
+    it "should not raise any errors when the preconditions are satisfied" do
+      @stack.push(value = 42)
+      assert_equal value, @stack.peek
     end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -9,4 +9,4 @@ end
 $LOAD_PATH.unshift File.expand_path("../lib", __dir__)
 require "standard_assert"
 
-require "test/unit"
+require "minitest/autorun"


### PR DESCRIPTION
This PR migrates the followings to `minitest`:

* Assertion methods' backend
* Testing library for testing the gem